### PR TITLE
docs: add end-user onboarding explainer

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -26,6 +26,7 @@
     * [COTI vs others](how-coti-works/advanced-topics/coti-vs-others.md)
 * [Build on COTI](build-on-coti/README.md)
   * [Core Concepts](build-on-coti/core-concepts/README.md)
+    * [What Is Onboarding?](build-on-coti/core-concepts/what-is-onboarding.md)
     * [Account Onboarding Procedure](build-on-coti/core-concepts/onboard-user.md)
     * [Private Data Types](build-on-coti/core-concepts/secure-data-types.md)
     * [Supported Operations on Private Data Types](build-on-coti/core-concepts/secure-operations-and-gas.md)

--- a/build-on-coti/core-concepts/onboard-user.md
+++ b/build-on-coti/core-concepts/onboard-user.md
@@ -4,6 +4,8 @@ Account Onboarding is a procedure that is needed to acquire the EOA unique AES k
 
 Once the EOA is created and funded with native coin, it needs to be onboarded to the system to obtain an AES key.&#x20;
 
+For a plain-language explanation for end users, see [What Is Onboarding?](what-is-onboarding.md).
+
 See the [guide for onboarding an account](../guides/account-onboard.md).
 
 After completing the Account Onboard step the wallet has a functional account with the necessary credentials (having own AES key) allowing it to start interacting with the gcEVM operations, including running smart contracts or performing other actions as needed.

--- a/build-on-coti/core-concepts/what-is-onboarding.md
+++ b/build-on-coti/core-concepts/what-is-onboarding.md
@@ -1,0 +1,35 @@
+# What Is Onboarding?
+
+Onboarding is the one-time setup that gives your wallet its encryption key for private on-chain data. A short COTI Network transaction **retrieves** that key (your AES key) for your wallet address so you can encrypt and decrypt private on-chain values.
+
+Until the key is available in your wallet session, you can still use the network normally (public transfers, gas, non-private contracts). You **cannot** read or write private data — for example private balances, amounts, or other encrypted contract variables.
+
+When a dApp needs access to private data, it will ask you to complete onboarding by approving that transaction in your wallet.
+
+{% hint style="info" %}
+**Developers:** see [Account Onboarding Procedure](onboard-user.md) and [Account Onboard](../guides/account-onboard.md).
+{% endhint %}
+
+## Why do I need it?
+
+Private values on COTI are stored encrypted. Encryption and decryption use a key that belongs only to **your** wallet account ([EOA](../../support-and-community/glossary.md#account)).
+
+Your wallet needs that key to:
+
+* **encrypt** inputs before private transactions
+* **decrypt** outputs when you need to see private values
+
+Without it, private features stay locked. The network already associates a unique AES key with your address; onboarding is how your wallet **receives** that key (first time) or **recovers** it again (new device, cleared storage, reinstall). Recovering always returns the **same** key for that address — it does not issue a new one.
+
+## What is the encryption key?
+
+* One AES key per wallet address — not shared across accounts
+* Used only for **your** private data on COTI
+* Held by your wallet / dApp session (for MetaMask users, often inside the [COTI Snap](../tools/coti-metamask-snap/README.md)); you usually never need to copy it
+* Delivered wrapped so only your wallet can open it — not left as plaintext for others to read on-chain
+
+{% hint style="danger" %}
+Treat your AES key like your wallet private key. Anyone who has it can decrypt your private on-chain data. Never share your AES key, seed phrase, or private key.
+{% endhint %}
+
+Technical detail: [AES Keys](../../how-coti-works/advanced-topics/aes-keys.md).

--- a/build-on-coti/tools/coti-metamask-snap/README.md
+++ b/build-on-coti/tools/coti-metamask-snap/README.md
@@ -30,6 +30,8 @@ Once the snap is installed, the MetaMask site will offer to continue to COTI's c
 
 #### **2. Onboard Account (Retrieve AES Key)**
 
+For a plain-language overview, see [What Is Onboarding?](../../core-concepts/what-is-onboarding.md).
+
 Once you are in the companion dApp site ([metamask.coti.io](https://metamask.coti.io)):
 
 1. Click on the "**Connect Wallet**" button, follow the prompts on MetaMask.

--- a/coti-privacy-portal/user-guide/README.md
+++ b/coti-privacy-portal/user-guide/README.md
@@ -25,6 +25,7 @@ This helps keep your financial data confidential.
 This guide will walk you through how to:
 
 * connect your wallet to the Privacy Portal
+* [onboard](../../build-on-coti/core-concepts/what-is-onboarding.md) so private features can unlock
 * bridge public tokens into private tokens
 * send and receive private transactions
 * view your balances securely


### PR DESCRIPTION
Plain-language what/why for the AES key privacy setup.